### PR TITLE
Fix interval identifier bug with Null values

### DIFF
--- a/src/pywrangler/pyspark/testing.py
+++ b/src/pywrangler/pyspark/testing.py
@@ -12,6 +12,31 @@ try:
 except ImportError:
     from pandas.util.testing import assert_frame_equal
 
+# constant for pandas missing NULL values
+PANDAS_NULL = object()
+
+
+def prepare_spark_conversion(df: pd.DataFrame) -> pd.DataFrame:
+    """Pandas does not distinguish NULL and NaN values. Everything null-like
+    is converted to NaN. However, spark does distinguish NULL and NaN for
+    example. To enable correct spark dataframe creation with NULL and NaN
+    values, the `PANDAS_NULL` constant is used as a workaround to enforce NULL
+    values in pyspark dataframes. Pyspark treats `None` values as NULL.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Input dataframe to be prepared.
+
+    Returns
+    -------
+    df_prepared: pd.DataFrame
+        Prepared dataframe for spark conversion.
+
+    """
+
+    return df.where(df.ne(PANDAS_NULL), None)
+
 
 def assert_pyspark_pandas_equality(df_spark: DataFrame,
                                    df_pandas: pd.DataFrame,
@@ -43,12 +68,28 @@ def assert_pyspark_pandas_equality(df_spark: DataFrame,
 
     """
 
+    df_spark = df_spark.toPandas()
+
+    # check for non matching columns and enforce identical column order
+    mismatch_columns = df_pandas.columns.symmetric_difference(df_spark.columns)
+    if not mismatch_columns.empty:
+        raise AssertionError("Column names do not match: {}"
+                             .format(mismatch_columns.tolist()))
+    else:
+        df_spark = df_spark[df_pandas.columns]
+
+    # enforce identical row order
     orderby = orderby or df_pandas.columns.tolist()
 
     def prepare_compare(df):
-        return df.sort_values(orderby).reset_index(drop=True)
+        df = df.sort_values(orderby).reset_index(drop=True)
+        df = df.where((pd.notnull(df)), None)
+        return df
 
-    df_spark = prepare_compare(df_spark.toPandas())
     df_pandas = prepare_compare(df_pandas)
+    df_spark = prepare_compare(df_spark)
 
-    assert_frame_equal(df_spark, df_pandas, check_like=True)
+    assert_frame_equal(df_spark,
+                       df_pandas,
+                       check_like=False,
+                       check_dtype=False)

--- a/src/pywrangler/pyspark/wranglers/interval_identifier.py
+++ b/src/pywrangler/pyspark/wranglers/interval_identifier.py
@@ -73,8 +73,8 @@ class VectorizedCumSum(PySparkSingleNoFit, IntervalIdentifier):
 
         # get boolean series with start and end markers
         marker_col = F.col(self.marker_column)
-        bool_start = (marker_col == self.marker_start).cast("integer")
-        bool_end = (marker_col == self.marker_end).cast("integer")
+        bool_start = marker_col.eqNullSafe(self.marker_start).cast("integer")
+        bool_end = marker_col.eqNullSafe(self.marker_end).cast("integer")
         bool_start_end = bool_start + bool_end
 
         # shifting the close marker allows cumulative sum to include the end

--- a/tests/pandas/wranglers/test_interval_identifier.py
+++ b/tests/pandas/wranglers/test_interval_identifier.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from tests.test_data.interval_identifier import (
@@ -45,7 +46,10 @@ MARKER_TYPES = {"string": {"start": "start",
 
                 "float": {"start": 1.1,
                           "end": 1.2,
-                          "noise": 1.3}}
+                          "noise": 1.3},
+                "nan": {"start": 1,
+                        "end": 2,
+                        "noise": np.NaN}}
 
 MARKERS = MARKER_TYPES.values()
 MARKERS_IDS = list(MARKER_TYPES.keys())
@@ -159,7 +163,7 @@ def test_groupby_order_columns(test_case, wrangler, marker, shuffle):
                                  **kwargs)
 
     test_output = wrangler_instance.fit_transform(test_input)
-    assert_frame_equal(test_output, expected)
+    assert_frame_equal(test_output, expected, check_dtype=False)
 
 
 @pytest.mark.parametrize(**GROUPBY_ORDER_KWARGS)
@@ -197,4 +201,4 @@ def test_no_groupby_order_columns(test_case, wrangler, groupby_order):
                                  **groupby_order)
 
     test_output = wrangler_instance.fit_transform(test_input)
-    assert_frame_equal(test_output, expected)
+    assert_frame_equal(test_output, expected, check_dtype=False)


### PR DESCRIPTION
Adresses #13. 

-  [ ] Reconsider pandas -> spark NULL values
-  [ ] Add tests modified pyspark testing functions