### PR TITLE
Feature iid issue #15

### DIFF
--- a/src/pywrangler/pandas/wranglers/interval_identifier.py
+++ b/src/pywrangler/pandas/wranglers/interval_identifier.py
@@ -122,7 +122,7 @@ class NaiveIterator(_BaseIntervalIdentifier):
 
         """
 
-        if self._naive_algorithm:
+        if self._identical_start_end_markers:
             return self._transform_start_only(series)
         else:
             return self._transform_start_and_end(series)
@@ -221,7 +221,7 @@ class VectorizedCumSum(_BaseIntervalIdentifier):
         # get boolean series with start and end markers
         bool_start = series.eq(self.marker_start)
 
-        if self._naive_algorithm:
+        if self._identical_start_end_markers:
             return bool_start.cumsum()
 
         bool_end = series.eq(self.marker_end)

--- a/src/pywrangler/pyspark/wranglers/interval_identifier.py
+++ b/src/pywrangler/pyspark/wranglers/interval_identifier.py
@@ -76,7 +76,7 @@ class VectorizedCumSum(PySparkSingleNoFit, IntervalIdentifier):
         bool_start = marker_col.eqNullSafe(self.marker_start).cast("integer")
 
         # account for identical start and end markers
-        if self._naive_algorithm:
+        if self._identical_start_end_markers:
             ser_id = F.sum(bool_start).over(w_lag)
             return df.withColumn(self.target_column_name, ser_id)
 

--- a/src/pywrangler/pyspark/wranglers/interval_identifier.py
+++ b/src/pywrangler/pyspark/wranglers/interval_identifier.py
@@ -71,31 +71,47 @@ class VectorizedCumSum(PySparkSingleNoFit, IntervalIdentifier):
         w_lag = Window.partitionBy(groupby).orderBy(orderby)
         w_id = Window.partitionBy(groupby + [self.target_column_name])
 
-        # get boolean series with start and end markers
-        marker_col = F.col(self.marker_column)
-        bool_start = marker_col.eqNullSafe(self.marker_start).cast("integer")
-        bool_end = marker_col.eqNullSafe(self.marker_end).cast("integer")
-        bool_start_end = bool_start + bool_end
+        if self._naive_algorithm:
+            # identical marker for start and end
+            # get boolean series with start and end markers
+            marker_col = F.col(self.marker_column)
+            bool_start = marker_col.eqNullSafe(self.marker_start).cast(
+                "integer")
 
-        # shifting the close marker allows cumulative sum to include the end
-        bool_end_shift = F.lag(bool_end, default=1).over(w_lag).cast("integer")
-        bool_start_end_shift = bool_start + bool_end_shift
+            # get increasing ids for intervals (in/valid) with cumsum
+            ser_id = F.sum(bool_start).over(w_lag)
 
-        # get increasing ids for intervals (in/valid) with cumsum
-        ser_id = F.sum(bool_start_end_shift).over(w_lag)
+            # ser_id needs be created temporarily for renumerate_adjusted
+            return df.withColumn(self.target_column_name, ser_id)
 
-        # separate valid vs invalid: ids with start AND end marker are valid
-        bool_valid = F.sum(bool_start_end).over(w_id) == 2
-        valid_ids = F.when(bool_valid, ser_id).otherwise(0)
+        else:
+            # difference marker for start and end
+            # get boolean series with start and end markers
+            marker_col = F.col(self.marker_column)
+            bool_start = marker_col.eqNullSafe(self.marker_start).cast(
+                "integer")
+            bool_end = marker_col.eqNullSafe(self.marker_end).cast("integer")
+            bool_start_end = bool_start + bool_end
 
-        # re-numerate ids from 1 to x and fill invalid with 0
-        valid_ids_shift = F.lag(valid_ids, default=0).over(w_lag)
-        valid_ids_diff = valid_ids_shift - valid_ids
-        valid_ids_increase = (valid_ids_diff < 0).cast("integer")
+            # shifting the close marker allows cumulative sum to include the end
+            bool_end_shift = F.lag(bool_end, default=1).over(w_lag).cast("integer")
+            bool_start_end_shift = bool_start + bool_end_shift
 
-        renumerate = F.sum(valid_ids_increase).over(w_lag)
-        renumerate_adjusted = F.when(bool_valid, renumerate).otherwise(0)
+            # get increasing ids for intervals (in/valid) with cumsum
+            ser_id = F.sum(bool_start_end_shift).over(w_lag)
 
-        # ser_id needs be created temporarily for renumerate_adjusted
-        return df.withColumn(self.target_column_name, ser_id) \
-            .withColumn(self.target_column_name, renumerate_adjusted)
+            # separate valid vs invalid: ids with start AND end marker are valid
+            bool_valid = F.sum(bool_start_end).over(w_id) == 2
+            valid_ids = F.when(bool_valid, ser_id).otherwise(0)
+
+            # re-numerate ids from 1 to x and fill invalid with 0
+            valid_ids_shift = F.lag(valid_ids, default=0).over(w_lag)
+            valid_ids_diff = valid_ids_shift - valid_ids
+            valid_ids_increase = (valid_ids_diff < 0).cast("integer")
+
+            renumerate = F.sum(valid_ids_increase).over(w_lag)
+            renumerate_adjusted = F.when(bool_valid, renumerate).otherwise(0)
+
+            # ser_id needs be created temporarily for renumerate_adjusted
+            return df.withColumn(self.target_column_name, ser_id) \
+                .withColumn(self.target_column_name, renumerate_adjusted)

--- a/src/pywrangler/wranglers.py
+++ b/src/pywrangler/wranglers.py
@@ -8,7 +8,7 @@ from pywrangler.base import BaseWrangler
 from pywrangler.util import sanitizer
 from pywrangler.util.types import TYPE_ASCENDING, TYPE_COLUMNS
 
-NULL = object()
+NONEVALUE = object()
 
 
 class IntervalIdentifier(BaseWrangler):
@@ -17,7 +17,8 @@ class IntervalIdentifier(BaseWrangler):
 
     An interval is defined as a range of values beginning with an opening
     marker and ending with a closing marker (e.g. the interval daylight may be
-    defined as all events/values occurring between sunrise and sunset).
+    defined as all events/values occurring between sunrise and sunset). Start
+    and end marker may be identical.
 
     The interval identification wrangler assigns ids to values such that values
     belonging to the same interval share the same interval id. For example, all
@@ -25,7 +26,8 @@ class IntervalIdentifier(BaseWrangler):
     the second daylight interval will be assigned with id 2 and so on.
 
     Values which do not belong to any valid interval are assigned the value 0
-    by definition.
+    by definition (if start and end marker are identical, there are only
+    invalid values possible before the first start marker is encountered).
 
     Only the shortest valid interval is identified. Given multiple opening
     markers in sequence without an intermittent closing marker, only the last
@@ -62,7 +64,7 @@ class IntervalIdentifier(BaseWrangler):
     def __init__(self,
                  marker_column: str,
                  marker_start,
-                 marker_end: Any = NULL,
+                 marker_end: Any = NONEVALUE,
                  order_columns: TYPE_COLUMNS = None,
                  groupby_columns: TYPE_COLUMNS = None,
                  ascending: TYPE_ASCENDING = None,
@@ -76,7 +78,8 @@ class IntervalIdentifier(BaseWrangler):
         self.ascending = sanitizer.ensure_iterable(ascending)
         self.target_column_name = target_column_name
 
-        self._naive_algorithm = marker_end == NULL
+        # check for identical start and end values
+        self._naive_algorithm = marker_end == NONEVALUE
 
         # sanity checks for sort order
         if self.ascending:

--- a/src/pywrangler/wranglers.py
+++ b/src/pywrangler/wranglers.py
@@ -44,7 +44,8 @@ class IntervalIdentifier(BaseWrangler):
     marker_start: Any
         A value defining the start of an interval.
     marker_end: Any, optional
-        A value defining the end of an interval, if necessary
+        A value defining the end of an interval. This value is optional. If not
+        given, the end marker equals the start marker.
     order_columns: str, Iterable[str], optional
         Column names which define the order of the data (e.g. a timestamp
         column). Sort order can be defined with the parameter `ascending`.
@@ -79,7 +80,8 @@ class IntervalIdentifier(BaseWrangler):
         self.target_column_name = target_column_name
 
         # check for identical start and end values
-        self._naive_algorithm = marker_end == NONEVALUE
+        self._identical_start_end_markers = ((marker_end == NONEVALUE) or
+                                             (marker_start == marker_end))
 
         # sanity checks for sort order
         if self.ascending:

--- a/src/pywrangler/wranglers.py
+++ b/src/pywrangler/wranglers.py
@@ -2,11 +2,13 @@
 and corresponding descriptions.
 
 """
-
+from typing import Any
 
 from pywrangler.base import BaseWrangler
 from pywrangler.util import sanitizer
 from pywrangler.util.types import TYPE_ASCENDING, TYPE_COLUMNS
+
+NULL = object()
 
 
 class IntervalIdentifier(BaseWrangler):
@@ -39,8 +41,8 @@ class IntervalIdentifier(BaseWrangler):
         Name of column which contains the opening and closing markers.
     marker_start: Any
         A value defining the start of an interval.
-    marker_end: Any
-        A value defining the end of an interval.
+    marker_end: Any, optional
+        A value defining the end of an interval, if necessary
     order_columns: str, Iterable[str], optional
         Column names which define the order of the data (e.g. a timestamp
         column). Sort order can be defined with the parameter `ascending`.
@@ -60,7 +62,7 @@ class IntervalIdentifier(BaseWrangler):
     def __init__(self,
                  marker_column: str,
                  marker_start,
-                 marker_end,
+                 marker_end: Any = NULL,
                  order_columns: TYPE_COLUMNS = None,
                  groupby_columns: TYPE_COLUMNS = None,
                  ascending: TYPE_ASCENDING = None,
@@ -73,6 +75,8 @@ class IntervalIdentifier(BaseWrangler):
         self.groupby_columns = sanitizer.ensure_iterable(groupby_columns)
         self.ascending = sanitizer.ensure_iterable(ascending)
         self.target_column_name = target_column_name
+
+        self._naive_algorithm = marker_end == NULL
 
         # sanity checks for sort order
         if self.ascending:

--- a/tests/pandas/wranglers/test_interval_identifier.py
+++ b/tests/pandas/wranglers/test_interval_identifier.py
@@ -20,8 +20,8 @@ from tests.test_data.interval_identifier import (
     single_interval,
     single_interval_spanning,
     start_marker_left_open,
-    starts_with_single_interval
-)
+    starts_with_single_interval,
+    identical_start_end_with_invalids)
 
 from pywrangler.pandas.wranglers.interval_identifier import (
     NaiveIterator,
@@ -201,4 +201,21 @@ def test_no_groupby_order_columns(test_case, wrangler, groupby_order):
                                  **groupby_order)
 
     test_output = wrangler_instance.fit_transform(test_input)
+
+    assert_frame_equal(test_output, expected)
+
+
+@pytest.mark.parametrize(**MARKERS_KWARGS)
+def test_identical_start_end_marker(marker):
+    test_input, expected = identical_start_end_with_invalids(start=marker["start"],
+                                                             noise=marker["noise"],
+                                                             target_column_name="iids")
+
+    wrangler_instance = VectorizedCumSum(marker_column="marker",
+                                         marker_start=marker["start"],
+                                         order_columns="order",
+                                         groupby_columns="groupby")
+
+    test_output = wrangler_instance.fit_transform(test_input)
+
     assert_frame_equal(test_output, expected, check_dtype=False)

--- a/tests/pandas/wranglers/test_interval_identifier.py
+++ b/tests/pandas/wranglers/test_interval_identifier.py
@@ -21,7 +21,8 @@ from tests.test_data.interval_identifier import (
     single_interval_spanning,
     start_marker_left_open,
     starts_with_single_interval,
-    identical_start_end_with_invalids)
+    identical_start_end_with_invalids,
+    identical_start_end_with_invalids_unsorted)
 
 from pywrangler.pandas.wranglers.interval_identifier import (
     NaiveIterator,
@@ -94,6 +95,13 @@ TEST_CASES_NO_ORDER_GROUP_IDS = [x.__name__ for x in TEST_CASES_NO_ORDER_GROUP]
 TEST_CASES_NO_ORDER_GROUP_KWARGS = dict(argnames='test_case',
                                         argvalues=TEST_CASES_NO_ORDER_GROUP,
                                         ids=TEST_CASES_NO_ORDER_GROUP_IDS)
+
+TEST_CASES_IDENTICAL = (identical_start_end_with_invalids,
+                        identical_start_end_with_invalids_unsorted)
+TEST_CASE_IDENTICAL_IDS = [x.__name__ for x in TEST_CASES_IDENTICAL]
+TEST_CASE_IDENTICAL_KWARGS = dict(argnames='test_case',
+                                  argvalues=TEST_CASES_IDENTICAL,
+                                  ids=TEST_CASE_IDENTICAL_IDS)
 
 GROUPBY_ORDER_TYPES = {'no_order': {'groupby_columns': 'groupby'},
                        'no_groupby': {'order_columns': 'order'},
@@ -205,16 +213,19 @@ def test_no_groupby_order_columns(test_case, wrangler, groupby_order):
     assert_frame_equal(test_output, expected)
 
 
+@pytest.mark.parametrize(**TEST_CASE_IDENTICAL_KWARGS)
 @pytest.mark.parametrize(**MARKERS_KWARGS)
-def test_identical_start_end_marker(marker):
-    test_input, expected = identical_start_end_with_invalids(start=marker["start"],
-                                                             noise=marker["noise"],
-                                                             target_column_name="iids")
+@pytest.mark.parametrize(**WRANGLER_KWARGS)
+def test_identical_start_end_marker(wrangler, marker, test_case):
+    test_input, expected = test_case(
+        start=marker["start"],
+        noise=marker["noise"],
+        target_column_name="iids")
 
-    wrangler_instance = VectorizedCumSum(marker_column="marker",
-                                         marker_start=marker["start"],
-                                         order_columns="order",
-                                         groupby_columns="groupby")
+    wrangler_instance = wrangler(marker_column="marker",
+                                 marker_start=marker["start"],
+                                 order_columns="order",
+                                 groupby_columns="groupby")
 
     test_output = wrangler_instance.fit_transform(test_input)
 

--- a/tests/pyspark/conftest.py
+++ b/tests/pyspark/conftest.py
@@ -1,6 +1,7 @@
 """pytest configuration
 
 """
+import multiprocessing
 
 import multiprocessing
 

--- a/tests/pyspark/wranglers/test_interval_identifier.py
+++ b/tests/pyspark/wranglers/test_interval_identifier.py
@@ -34,8 +34,8 @@ from tests.test_data.interval_identifier import (
     single_interval_spanning,
     start_marker_left_open,
     starts_with_single_interval,
-    identical_start_end_with_invalids
-)
+    identical_start_end_with_invalids,
+    identical_start_end_with_invalids_unsorted)
 
 MARKER_TYPES = {"string": {"start": "start.start!2",
                            "end": "end.end#4",
@@ -95,6 +95,13 @@ TEST_CASES_NO_ORDER_GROUP_IDS = [x.__name__ for x in TEST_CASES_NO_ORDER_GROUP]
 TEST_CASES_NO_ORDER_GROUP_KWARGS = dict(argnames='test_case',
                                         argvalues=TEST_CASES_NO_ORDER_GROUP,
                                         ids=TEST_CASES_NO_ORDER_GROUP_IDS)
+
+TEST_CASES_IDENTICAL = (identical_start_end_with_invalids,
+                        identical_start_end_with_invalids_unsorted)
+TEST_CASE_IDENTICAL_IDS = [x.__name__ for x in TEST_CASES_IDENTICAL]
+TEST_CASE_IDENTICAL_KWARGS = dict(argnames='test_case',
+                                  argvalues=TEST_CASES_IDENTICAL,
+                                  ids=TEST_CASE_IDENTICAL_IDS)
 
 GROUPBY_ORDER_TYPES = {'no_order': {'groupby_columns': 'groupby'},
                        'no_groupby': {'order_columns': 'order'},
@@ -288,12 +295,15 @@ def test_groupby_multiple_intervals_null(wrangler, marker, shuffle,
 
     assert_pyspark_pandas_equality(test_output, expected)
 
-@pytest.mark.parametrize(**MARKERS_KWARGS)
-def test_identical_start_end_marker(marker, spark):
 
-    test_input, expected = identical_start_end_with_invalids(start=marker["start"],
-                                                             noise=marker["noise"],
-                                                             target_column_name="iids")
+@pytest.mark.parametrize(**TEST_CASE_IDENTICAL_KWARGS)
+@pytest.mark.parametrize(**MARKERS_KWARGS)
+@pytest.mark.parametrize(**WRANGLER_KWARGS)
+def test_identical_start_end_marker(wrangler, marker, test_case, spark):
+    test_input, expected = test_case(
+        start=marker["start"],
+        noise=marker["noise"],
+        target_column_name="iids")
 
     expected = pd.merge(test_input, expected, left_index=True,
                         right_index=True)
@@ -302,9 +312,9 @@ def test_identical_start_end_marker(marker, spark):
     kwargs = {"order_columns": "order",
               "groupby_columns": "groupby"}
 
-    wrangler_instance = VectorizedCumSum(marker_column="marker",
-                                         marker_start=marker["start"],
-                                         **kwargs)
+    wrangler_instance = wrangler(marker_column="marker",
+                                 marker_start=marker["start"],
+                                 **kwargs)
 
     test_output = wrangler_instance.fit_transform(test_input)
     assert_pyspark_pandas_equality(test_output, expected)

--- a/tests/test_data/interval_identifier.py
+++ b/tests/test_data/interval_identifier.py
@@ -357,21 +357,42 @@ def multiple_groupby_order_columns_with_invalids(start, end, noise,
 
 
 def identical_start_end_with_invalids(start, noise, target_column_name):
-    # cols:     order, groupby, marker, iid
-    data = [[1, 1, noise, 0],
-            [2, 1, start, 1],
-            [3, 1, start, 2],
-            [4, 1, noise, 2],
+    # cols:  order, groupby, marker, iid
+    data = [[1,     1,       noise,  0],
+            [2,     1,       start,  1],
+            [3,     1,       start,  2],
+            [4,     1,       noise,  2],
 
-            [5, 2, start, 1],
-            [6, 2, noise, 1],
-            [7, 2, start, 2],
-            [8, 2, noise, 2],
-            [9, 2, noise, 2],
-            [10, 2, start, 3],
-            [11, 2, noise, 3],
-            [12, 2, start, 4],
-            [13, 2, noise, 4],
-            [14, 2, start, 5]]
+            [5,     2,       start,  1],
+            [6,     2,       noise,  1],
+            [7,     2,       start,  2],
+            [8,     2,       noise,  2],
+            [9,     2,       noise,  2],
+            [10,    2,       start,  3],
+            [11,    2,       noise,  3],
+            [12,    2,       start,  4],
+            [13,    2,       noise,  4],
+            [14,    2,       start,  5]]
+
+    return _return_dfs(data, target_column_name)
+
+
+def identical_start_end_with_invalids_unsorted(start, noise,
+                                               target_column_name):
+    # cols:  order, groupby, marker, iid
+    data = [[1,     1,       noise,  0],
+            [13,    2,       noise,  4],
+            [3,     1,       start,  2],
+            [8,     2,       noise,  2],
+            [7,     2,       start,  2],
+            [4,     1,       noise,  2],
+            [5,     2,       start,  1],
+            [6,     2,       noise,  1],
+            [9,     2,       noise,  2],
+            [10,    2,       start,  3],
+            [2,     1,       start,  1],
+            [11,    2,       noise,  3],
+            [12,    2,       start,  4],
+            [14,    2,       start,  5]]
 
     return _return_dfs(data, target_column_name)

--- a/tests/test_data/interval_identifier.py
+++ b/tests/test_data/interval_identifier.py
@@ -354,3 +354,24 @@ def multiple_groupby_order_columns_with_invalids(start, end, noise,
             [4,      2,      2,        2,        end,    0]]
 
     return _return_dfs(data, target_column_name, shuffle=shuffle)
+
+
+def identical_start_end_with_invalids(start, noise, target_column_name):
+    # cols:     order, groupby, marker, iid
+    data = [[1, 1, noise, 0],
+            [2, 1, start, 1],
+            [3, 1, start, 2],
+            [4, 1, noise, 2],
+
+            [5, 2, start, 1],
+            [6, 2, noise, 1],
+            [7, 2, start, 2],
+            [8, 2, noise, 2],
+            [9, 2, noise, 2],
+            [10, 2, start, 3],
+            [11, 2, noise, 3],
+            [12, 2, start, 4],
+            [13, 2, noise, 4],
+            [14, 2, start, 5]]
+
+    return _return_dfs(data, target_column_name)


### PR DESCRIPTION
Hi @mansenfranzen  
Issue #15 should be done with this PR.

- IntervalIdentifier is able to use only 'marker_start' for creating intervals
- 'transform'- functions in VectorizedCumSum is enhanced for pyspark and pandas
- adding tests 'test_identical_start_end_marker' for pyspark and pandas