### PR TITLE
Patch `SparkSession.createDataFrame` to cache results for faster test…

### DIFF
--- a/tests/util/testing/test_plainframe.py
+++ b/tests/util/testing/test_plainframe.py
@@ -94,7 +94,7 @@ def df_from_spark(spark):
 
     schema = types.StructType(columns)
 
-    return spark.createDataFrame(data, schema)
+    return spark.createDataFrame(data, schema=schema)
 
 
 def create_plain_frame(cols, rows, reverse_cols=False, reverse_rows=False):


### PR DESCRIPTION
...performance. Addresses #10.