### PR TITLE
make call to lag-function compatible with PySpark >= 3.0.0

### DIFF
--- a/src/pywrangler/pyspark/wranglers/interval_identifier.py
+++ b/src/pywrangler/pyspark/wranglers/interval_identifier.py
@@ -539,7 +539,7 @@ class VectorizedCumSumAdjusted(VectorizedCumSum):
             ff_window)
 
         # shifting marker_col forward
-        shift_col = F.lag(forward_fill_col, default=default, count=1) \
+        shift_col = F.lag(forward_fill_col, default=default, offset=1) \
             .over(window) \
             .cast("integer")
 


### PR DESCRIPTION
The changed function signature was introduced with PySpark Version 3.0.0